### PR TITLE
Ensure the full path of the current file is used. Otherwise, errors can ...

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -231,7 +231,7 @@ function! s:CursorHoldUpdate()
 endfunction
 
 if g:NERDTreeUpdateOnWrite == 1
-    autocmd BufWritePost * call s:FileUpdate(expand("%"))
+    autocmd BufWritePost * call s:FileUpdate(expand("%:p"))
 endif
 " FUNCTION: s:FileUpdate(fname) {{{2
 function! s:FileUpdate(fname)


### PR DESCRIPTION
...occurr when saving changes.

The expand("%") call only expands to the current filename, not the full path of the current file. The receiving function sometimes fails without the full path, causing NERDTree to issue error messages over my vim session. Please review and if you agree with my edit, consider merging my pull request please.

Thanks,
Dean Hallman

P.S. Thanks for this great vim plugin. The fact the I spent time finding/repairing this issue is a testament to how useful I think it is.
