### PR TITLE
Case-Sensitive FileType

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -254,7 +254,7 @@ function! s:FileUpdate(fname)
     call NERDTreeRender()
 endfunction
 
-autocmd filetype nerdtree call s:AddHighlighting()
+autocmd FileType nerdtree call s:AddHighlighting()
 function! s:AddHighlighting()
     syn match NERDTreeGitStatusModified #✹# containedin=NERDTreeFlags
     syn match NERDTreeGitStatusAdded #✚# containedin=NERDTreeFlags


### PR DESCRIPTION
With vim 7.4 (at least patch 507) autocmd is seems to got case sensitive regarding filetype.
I receive the following error upon opening vim for some time:

> Error detected while processing /home/mp/.vim/bundle/nerdtree-git-plugin/nerdtree_plugin/git_status.vim:
> line  257:
> E216: No such event: nerdtree call s:AddHighlighting()
