### PR TITLE
Preserve alignment

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -162,7 +162,7 @@ function! s:NERDTreeGetIndicator(statusKey)
     if indicator != ""
         return indicator
     endif
-    return ''
+    return ' '
 endfunction
 
 function! s:NERDTreeGetFileGitStatusKey(us, them)


### PR DESCRIPTION
This is a hack which simply makes sure that the columns are aligned.

Below I have a new folder, `BarFoo`, but it is confusing (i.e. it is more difficult to see at first glance if `BarFoo` is really at the same level as `Metadata` and `Resource`):

````
▸ Factory/                     
▾ [✗]Repository/               
  ▸ BarFoo/                                                                                                                                                                        
  ▸ [✗]Metadata/               
  ▸ [✗]Resource/               
    [✚]AbstractPhpcrRepository.php
    Foobar.php                 
    [✚]PhpcrOdmRepository.php  
    [✚]PhpcrRepository.php     
▸ [✗]Tests/                    
````

This PR always adds the prefix:

````
▸ [ ]Factory/
▾ [✗]Repository/
  ▸ [ ]BarFoo/
  ▸ [✗]Metadata/
  ▸ [✗]Resource/
    [✚]AbstractPhpcrRepository.php
    Foobar.php                                                                                                                                                                     
    [✚]PhpcrOdmRepository.php
    [✚]PhpcrRepository.php
▸ [✗]Tests/
````

Which makes it easier to read.

Not a very good solution though.