### PR TITLE
Change the scope of s:NERDTreeIndicatorMap to the global

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -38,8 +38,8 @@ if !exists('g:NERDTreeUpdateOnCursorHold')
     let g:NERDTreeUpdateOnCursorHold = 1
 endif
 
-if !exists('s:NERDTreeIndicatorMap')
-    let s:NERDTreeIndicatorMap = {
+if !exists('g:NERDTreeIndicatorMap')
+    let g:NERDTreeIndicatorMap = {
                 \ "Modified"  : "✹",
                 \ "Staged"    : "✚",
                 \ "Untracked" : "✭",
@@ -158,7 +158,7 @@ function! g:NERDTreeGetCWDGitStatus()
 endfunction
 
 function! s:NERDTreeGetIndicator(statusKey)
-    let indicator = get(s:NERDTreeIndicatorMap, a:statusKey, "")
+    let indicator = get(g:NERDTreeIndicatorMap, a:statusKey, "")
     if indicator != ""
         return indicator
     endif


### PR DESCRIPTION
Currently `NERDTreeIndicatorMap` can't access from such as `.vimrc` because it has script scope.
This patch will enable you to access it.