### PR TITLE
Use 'NerdTree.root' instead of 'NerdTreeRoot'

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -72,7 +72,7 @@ function! g:NERDTreeGitStatusRefresh()
     let b:NERDTreeCachedGitDirtyDir   = {}
     let b:NOT_A_GIT_REPOSITORY        = 1
 
-    let l:root = b:NERDTreeRoot.path.str()
+    let l:root = b:NERDTree.root.path.str()
     let l:gitcmd = 'git -c color.status=false status -s'
     if exists('g:NERDTreeGitStatusIgnoreSubmodules')
         let l:gitcmd = l:gitcmd . ' --ignore-submodules'
@@ -139,7 +139,7 @@ function! g:NERDTreeGetGitStatusPrefix(path)
         call g:NERDTreeGitStatusRefresh()
     endif
     let l:pathStr = a:path.str()
-    let l:cwd = b:NERDTreeRoot.path.str() . a:path.Slash()
+    let l:cwd = b:NERDTree.root.path.str() . a:path.Slash()
     if nerdtree#runningWindows()
         let l:pathStr = a:path.WinToUnixPath(l:pathStr)
         let l:cwd = a:path.WinToUnixPath(l:cwd)
@@ -254,7 +254,7 @@ function! s:CursorHoldUpdate()
 
     let l:winnr = winnr()
     call g:NERDTree.CursorToTreeWin()
-    call b:NERDTreeRoot.refreshFlags()
+    call b:NERDTree.root.refreshFlags()
     call NERDTreeRender()
     exec l:winnr . 'wincmd w'
 endfunction
@@ -275,7 +275,7 @@ function! s:FileUpdate(fname)
     let l:winnr = winnr()
 
     call g:NERDTree.CursorToTreeWin()
-    let l:node = b:NERDTreeRoot.findNode(g:NERDTreePath.New(a:fname))
+    let l:node = b:NERDTree.root.findNode(g:NERDTreePath.New(a:fname))
     if l:node == {}
         return
     endif

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -52,6 +52,11 @@ if !exists('s:NERDTreeIndicatorMap')
                 \ }
 endif
 
+if exists('b:NERDTreeRoot')
+    let l:NERDRoot = b:NERDTreeRoot
+else
+    let l:NERDRoot = b:NERDTree.root
+endif
 
 function! NERDTreeGitStatusRefreshListener(event)
     if !exists('b:NOT_A_GIT_REPOSITORY')
@@ -72,7 +77,7 @@ function! g:NERDTreeGitStatusRefresh()
     let b:NERDTreeCachedGitDirtyDir   = {}
     let b:NOT_A_GIT_REPOSITORY        = 1
 
-    let l:root = b:NERDTree.root.path.str()
+    let l:root = l:NERDRoot.path.str()
     let l:gitcmd = 'git -c color.status=false status -s'
     if exists('g:NERDTreeGitStatusIgnoreSubmodules')
         let l:gitcmd = l:gitcmd . ' --ignore-submodules'
@@ -139,7 +144,7 @@ function! g:NERDTreeGetGitStatusPrefix(path)
         call g:NERDTreeGitStatusRefresh()
     endif
     let l:pathStr = a:path.str()
-    let l:cwd = b:NERDTree.root.path.str() . a:path.Slash()
+    let l:cwd = l:NERDRoot.path.str() . a:path.Slash()
     if nerdtree#runningWindows()
         let l:pathStr = a:path.WinToUnixPath(l:pathStr)
         let l:cwd = a:path.WinToUnixPath(l:cwd)
@@ -254,7 +259,7 @@ function! s:CursorHoldUpdate()
 
     let l:winnr = winnr()
     call g:NERDTree.CursorToTreeWin()
-    call b:NERDTree.root.refreshFlags()
+    call l:NERDRoot.refreshFlags()
     call NERDTreeRender()
     exec l:winnr . 'wincmd w'
 endfunction
@@ -275,7 +280,7 @@ function! s:FileUpdate(fname)
     let l:winnr = winnr()
 
     call g:NERDTree.CursorToTreeWin()
-    let l:node = b:NERDTree.root.findNode(g:NERDTreePath.New(a:fname))
+    let l:node = l:NERDRoot.findNode(g:NERDTreePath.New(a:fname))
     if l:node == {}
         return
     endif


### PR DESCRIPTION
`nerdtree-git-plugin` doesn't work with latest version of `NerdTree` because of replacement `NerdTreeRoot` to `NerdTree.root` in this commit: https://github.com/scrooloose/nerdtree/commit/d36b7936566f9913a0fa3925ba57214f17f302a3 . So this PR add compatibility with new `NerdTree` and it works for me well