### PR TITLE
node colorization, flag disableable, untracked subnodes, jumpingTo improvement, refactoring

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -54,7 +54,7 @@ if !exists('g:NERDTreeGitStatusIndicatorMap')
                 \ 'Renamed'   : '➜',
                 \ 'Unmerged'  : '═',
                 \ 'Unknown'   : '✗',
-                \ 'Deleted'   : '✗',
+                \ 'Deleted'   : '✖',
                 \ 'Dirty'     : '★',
                 \ 'Clean'     : '✔︎'
                 \ }
@@ -64,7 +64,7 @@ if !exists('g:NERDTreeGitStatusIndicatorMap')
                 \ 'Added'     : nr2char(8239),
                 \ 'Renamed'   : nr2char(8199),
                 \ 'Unmerged'  : nr2char(8200),
-                \ 'Deleted'   : nr2char(8200),
+                \ 'Deleted'   : nr2char(8287),
                 \ 'Unknown'   : nr2char(8195),
                 \ 'Dirty'     : nr2char(8202),
                 \ 'Clean'     : nr2char(8196)
@@ -352,8 +352,8 @@ function! s:AddHighlighting()
                 \ 'NERDTreeGitStatusModified'    : s:NERDTreeGetIndicator('Modified'),
                 \ 'NERDTreeGitStatusAdded'       : s:NERDTreeGetIndicator('Added'),
                 \ 'NERDTreeGitStatusRenamed'     : s:NERDTreeGetIndicator('Renamed'),
-                \ 'NERDTreeGitStatusUnknown'     : s:NERDTreeGetIndicator('Unknown'),
                 \ 'NERDTreeGitStatusDeleted'     : s:NERDTreeGetIndicator('Deleted'),
+                \ 'NERDTreeGitStatusUnknown'     : s:NERDTreeGetIndicator('Unknown'),
                 \ 'NERDTreeGitStatusDirDirty'    : s:NERDTreeGetIndicator('Dirty'),
                 \ 'NERDTreeGitStatusDirClean'    : s:NERDTreeGetIndicator('Clean')
                 \ }
@@ -368,12 +368,12 @@ function! s:AddHighlighting()
       endif
     endfor
 
+    hi def link NERDTreeGitStatusUnmerged NERDTreeGitUnmerged
     hi def link NERDTreeGitStatusModified NERDTreeGitModified
     hi def link NERDTreeGitStatusAdded NERDTreeGitAdded
     hi def link NERDTreeGitStatusRenamed  NERDTreeGitAdded
-    hi def link NERDTreeGitStatusUnmerged NERDTreeGitUnmerged
-    hi def link NERDTreeGitStatusUnknown NERDTreeGitUnknown
     hi def link NERDTreeGitStatusDeleted NERDTreeGitDeleted
+    hi def link NERDTreeGitStatusUnknown NERDTreeGitUnknown
     hi def link NERDTreeGitStatusDirDirty NERDTreeGitDirDirty
     hi def link NERDTreeGitStatusDirClean NERDTreeGitDirClean
 endfunction

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -69,6 +69,14 @@ if !exists('g:NERDTreeGitStatusIndicatorMap')
                 \ 'Dirty'     : nr2char(8202),
                 \ 'Clean'     : nr2char(8196)
                 \ }
+        " Hide the backets
+        augroup webdevicons_conceal_nerdtree_brackets
+          au!
+          autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\]" contained conceal containedin=ALL
+          autocmd FileType nerdtree syntax match hideBracketsInNerdTree ".\[" contained conceal containedin=ALL
+          autocmd FileType nerdtree setlocal conceallevel=3
+          autocmd FileType nerdtree setlocal concealcursor=nvic
+        augroup END
     endif
 endif
 
@@ -360,9 +368,9 @@ function! s:AddHighlighting()
 
     for l:name in keys(l:synmap)
       if g:NERDTreeGitStatusNodeColorization == 1
-          exec 'syn match '.l:name.' "'.l:synmap[l:name].'.*" containedin=NERDTreeDir'
-          exec 'syn match '.l:name.' "'.l:synmap[l:name].'.*" containedin=NERDTreeFile'
-          exec 'syn match '.l:name.' "'.l:synmap[l:name].'.*" containedin=NERDTreeExecFile'
+          exec 'syn match '.l:name.' ".*'.l:synmap[l:name].'.*" containedin=NERDTreeDir'
+          exec 'syn match '.l:name.' ".*'.l:synmap[l:name].'.*" containedin=NERDTreeFile'
+          exec 'syn match '.l:name.' ".*'.l:synmap[l:name].'.*" containedin=NERDTreeExecFile'
       else
         exec 'syn match ' . l:name . ' #' . escape(l:synmap[l:name], '~') . '# containedin=NERDTreeFlags'
       endif

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -116,7 +116,7 @@ function! g:NERDTreeGitStatusRefresh()
     " ?           ?    untracked
     " !           !    ignored
     " -------------------------------------------------
-    let l:gitcmd = 'git status -s -uall | sed -E ''s/^UU|^UD|^UA|^DU|^DD|^DA|^AU|^AA/1/g'' | sed -E ''s/^MM|^M |^ M|^  /2/g'' | sed -E ''s/^A\?|^A |^AM|^\?\?|^\? |^\?M/3/g'' | sed -E ''s/^RM|^R /4/g'' | sed -E ''s/^D |^DM/5/g'' | sort'
+    let l:gitcmd = 'git status --porcelain -uall | sed -E ''s/^UU|^UD|^UA|^DU|^DD|^DA|^AU|^AA/1/g'' | sed -E ''s/^MM|^M |^ M|^  /2/g'' | sed -E ''s/^A\?|^A |^AM|^\?\?|^\? |^\?M/3/g'' | sed -E ''s/^RM|^R /4/g'' | sed -E ''s/^D |^DM/5/g'' | sort'
     if exists('g:NERDTreeGitStatusIgnoreSubmodules')
         let l:gitcmd = l:gitcmd . ' --ignore-submodules'
         if g:NERDTreeGitStatusIgnoreSubmodules ==# 'all' || g:NERDTreeGitStatusIgnoreSubmodules ==# 'dirty' || g:NERDTreeGitStatusIgnoreSubmodules ==# 'untracked'

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -11,6 +11,7 @@
 " ============================================================================
 if exists('g:loaded_nerdtree_git_status')
     finish
+
 endif
 let g:loaded_nerdtree_git_status = 1
 
@@ -376,14 +377,14 @@ function! s:AddHighlighting()
       endif
     endfor
 
-    hi def link NERDTreeGitStatusUnmerged NERDTreeGitUnmerged
-    hi def link NERDTreeGitStatusModified NERDTreeGitModified
-    hi def link NERDTreeGitStatusAdded NERDTreeGitAdded
-    hi def link NERDTreeGitStatusRenamed  NERDTreeGitAdded
-    hi def link NERDTreeGitStatusDeleted NERDTreeGitDeleted
-    hi def link NERDTreeGitStatusUnknown NERDTreeGitUnknown
-    hi def link NERDTreeGitStatusDirDirty NERDTreeGitDirDirty
-    hi def link NERDTreeGitStatusDirClean NERDTreeGitDirClean
+    hi def link NERDTreeGitStatusUnmerged Function
+    hi def link NERDTreeGitStatusModified Special
+    hi def link NERDTreeGitStatusAdded Tag
+    hi def link NERDTreeGitStatusRenamed  Tag
+    hi def link NERDTreeGitStatusDeleted Comment
+    hi def link NERDTreeGitStatusUnknown Label
+    hi def link NERDTreeGitStatusDirDirty Special
+    hi def link NERDTreeGitStatusDirClean Tag
 endfunction
 
 function! s:SetupListeners()


### PR DESCRIPTION
Please review the git logic changes carefully - further testing would be much appreciated.
### Git logic changes

combinations.
A        [ MD]: becomes unknown
### Parameter changes

```
- add param     g:NERDTreeGitStatusIndicatorMap:        used instead of NERDTreeIndicatorMapCustom.
- remove param  g:NERDTreeIndicatorMapCustom:           obsolete.
- add param     g:NERDTreeGitStatusWithFlags:           whether the default flags should be used.
- add param     g:NERDTreeGitStatusNodeColorization:    whether the full node is colorized or just the flag from the map
```
### Color definitions

```
hi def link NERDTreeGitStatusModified NERDTreeGitModified
hi def link NERDTreeGitStatusAdded NERDTreeGitAdded
hi def link NERDTreeGitStatusRenamed  NERDTreeGitRenamed
hi def link NERDTreeGitStatusUnmerged NERDTreeGitUnmerged
hi def link NERDTreeGitStatusUnknown NERDTreeGitUnknown
hi def link NERDTreeGitStatusDirDirty NERDTreeGitDirDirty
hi def link NERDTreeGitStatusDirClean NERDTreeGitDirClean`
```
### Further changes
- jumpToHunk is now dynamicly jumping to the next indicators
