### PR TITLE
Use git status --porcelain

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -73,7 +73,7 @@ function! g:NERDTreeGitStatusRefresh()
     let b:NOT_A_GIT_REPOSITORY        = 1
 
     let l:root = b:NERDTree.root.path.str()
-    let l:gitcmd = 'git -c color.status=false status -s'
+    let l:gitcmd = 'git status --porcelain'
     if exists('g:NERDTreeGitStatusIgnoreSubmodules')
         let l:gitcmd = l:gitcmd . ' --ignore-submodules'
         if g:NERDTreeGitStatusIgnoreSubmodules ==# 'all' || g:NERDTreeGitStatusIgnoreSubmodules ==# 'dirty' || g:NERDTreeGitStatusIgnoreSubmodules ==# 'untracked'


### PR DESCRIPTION
This patch replaces the "git status" hack with the official way
that should be used in scripts.

From the documentation:

--porcelain
   Give the output in an easy-to-parse format for scripts. This is
   similar to the short output, but will remain stable across Git
   versions and regardless of user configuration. See below for
   details.