### PR TITLE
Do not update when a special buffer is selected

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -252,27 +252,37 @@ function! s:CursorHoldUpdate()
         return
     endif
 
+    " Do not update when a special buffer is selected
+    if !empty(&l:buftype)
+        return
+    endif
+
     let l:winnr = winnr()
+    let l:altwinnr = winnr('#')
+
     call g:NERDTree.CursorToTreeWin()
     call b:NERDTree.root.refreshFlags()
     call NERDTreeRender()
+
+    exec l:altwinnr . 'wincmd w'
     exec l:winnr . 'wincmd w'
 endfunction
 
 augroup nerdtreegitplugin
     autocmd BufWritePost * call s:FileUpdate(expand('%:p'))
 augroup END
-
 " FUNCTION: s:FileUpdate(fname) {{{2
 function! s:FileUpdate(fname)
     if g:NERDTreeUpdateOnWrite != 1
         return
     endif
+
     if !g:NERDTree.IsOpen()
         return
     endif
 
     let l:winnr = winnr()
+    let l:altwinnr = winnr('#')
 
     call g:NERDTree.CursorToTreeWin()
     let l:node = b:NERDTree.root.findNode(g:NERDTreePath.New(a:fname))
@@ -287,6 +297,8 @@ function! s:FileUpdate(fname)
     endwhile
 
     call NERDTreeRender()
+
+    exec l:altwinnr . 'wincmd w'
     exec l:winnr . 'wincmd w'
 endfunction
 


### PR DESCRIPTION
And “special” here, means anything else that a normal buffer (a file).

Additionally make sure we reset the alternate window as well so we can keep using that as expected.

For details why this fix is needed, please see this issue https://github.com/ctrlpvim/ctrlp.vim/issues/235 and the comments (mainly the last 5 or so) of this PR https://github.com/ctrlpvim/ctrlp.vim/pull/303