### PR TITLE
Use ';' instead of '&&' to execute two commands

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -80,7 +80,7 @@ function! g:NERDTreeGitStatusRefresh()
             let l:gitcmd = l:gitcmd . '=' . g:NERDTreeGitStatusIgnoreSubmodules
         endif
     endif
-    let l:statusesStr = system('cd "' . l:root . '" && ' . l:gitcmd)
+    let l:statusesStr = system('cd "' . l:root . '" ; ' . l:gitcmd)
     let l:statusesSplit = split(l:statusesStr, '\n')
     if l:statusesSplit != [] && l:statusesSplit[0] =~# 'fatal:.*'
         let l:statusesSplit = []


### PR DESCRIPTION
Some shells, e.g. fish-shell, don't support use of '&&'.
So, an error is occured with such shells.
