### PR TITLE
If project path contains '~'

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -158,7 +158,8 @@ function! g:NERDTreeGetGitStatusPrefix(path)
         let l:pathStr = a:path.WinToUnixPath(l:pathStr)
         let l:cwd = a:path.WinToUnixPath(l:cwd)
     endif
-    let l:pathStr = substitute(l:pathStr, fnameescape(l:cwd), '', '')
+    let l:cwd = substitute(l:cwd, '\~', '\\~', 'g')
+    let l:pathStr = substitute(l:pathStr, l:cwd, '', '')
     let l:statusKey = ''
     if a:path.isDirectory
         let l:statusKey = get(b:NERDTreeCachedGitDirtyDir, fnameescape(l:pathStr . '/'), '')


### PR DESCRIPTION
If the project path contains '~', it will cause errors like this:
```
Error detected while processing function <SNR>7_lod_cmd[3]..261[2]..262[12]..245[27]..248[7]..211[9]..209[32]..322[4]..NERDTreeGitStatusRefreshListener[5]..NE
RDTreeGetGitStatusPrefix:
line   13:
E33: No previous substitute regular expression
E33: No previous substitute regular expression
Error detected while processing function <SNR>7_lod_cmd[3]..261[2]..262[12]..245[27]..248[7]..211:
line    9:
E171: Missing :endif
Error detected while processing function <SNR>7_lod_cmd[3]..261[2]..262:
line   12:
E171: Missing :endif
```
For exmaple:
```
$mkdir a~b
$git init a~b
$cd a~b
$vim
```
Then, try `:NERDTreeToggle` in vim, you can see this error. [E33](http://vimdoc.sourceforge.net/htmldoc/message.html#E33) is the error details.
This is because in [substitute](http://vimdoc.sourceforge.net/htmldoc/eval.html#substitute()) function,  '~' has a special meaning.  So I escape the symbol in front of what the path is used.
Maybe my code is not elegant(I'm not familiar with viml.), but it is useful to solve this problem.

I found this problem because I have some git project on iCloud. And the path of iCloud is '~/Library/Mobile\ Documents/com\~apple\~CloudDocs/'.