### PR TITLE
Escape special characters before use in shell

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -77,7 +77,7 @@ function! g:NERDTreeGitStatusRefresh()
     let b:NERDTreeCachedGitDirtyDir   = {}
     let b:NOT_A_GIT_REPOSITORY        = 1
 
-    let l:root = b:NERDTree.root.path.str()
+    let l:root = fnamemodify(b:NERDTree.root.path.str(), ":p:S")
     let l:gitcmd = 'git -c color.status=false status -s'
     if g:NERDTreeShowIgnoredStatus
         let l:gitcmd = l:gitcmd . ' --ignored'


### PR DESCRIPTION
Plugin would not work if path to git repository root contained special
characters. With fnameescape chars are escaped before path are used in
shell.