### PR TITLE
Add configuration option to display a symbol even if there is no modification on a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Use this variable to change symbols.
 
 `let g:NERDTreeShowIgnoredStatus = 1` (a heavy feature may cost much more time)
 
-> How to add a symbol even on unmodified files
+> How to add a symbol even on unmodified files ?
 
-This is useful, if you want to have a consistent indentation.
+`let g:NERDTreeGitUnchangedIndicator = '✔︎'`
 
-`let g:NERDTreeGitUnchangedIndicator = '-'`
+This is especially useful in combination with [vim-devicons](https://github.com/ryanoasis/vim-devicons), because it allows you to keep a consistent indentation, regardless of git modification status.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Use this variable to change symbols.
 
 `let g:NERDTreeShowIgnoredStatus = 1` (a heavy feature may cost much more time)
 
+> How to add a symbol even on unmodified files
+
+This is useful, if you want to have a consistent indentation.
+
+`let g:NERDTreeGitUnchangedIndicator = '-'`
+
 ## Credits
 
 *  [scrooloose](https://github.com/scrooloose): Open API for me.

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -67,6 +67,8 @@ function! NERDTreeGitStatusRefreshListener(event)
     call l:path.flagSet.clearFlags('git')
     if l:flag !=# ''
         call l:path.flagSet.addFlag('git', l:flag)
+    else
+        call l:path.flagSet.addFlag('git', '-')
     endif
 endfunction
 

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -42,6 +42,10 @@ if !exists('g:NERDTreeShowIgnoredStatus')
     let g:NERDTreeShowIgnoredStatus = 0
 endif
 
+if !exists('g:NERDTreeGitUnchangedIndicator')
+    let g:NERDTreeGitUnchangedIndicator = ''
+endif
+
 if !exists('s:NERDTreeIndicatorMap')
     let s:NERDTreeIndicatorMap = {
                 \ 'Modified'  : '✹',
@@ -68,7 +72,7 @@ function! NERDTreeGitStatusRefreshListener(event)
     if l:flag !=# ''
         call l:path.flagSet.addFlag('git', l:flag)
     else
-        call l:path.flagSet.addFlag('git', '-')
+        call l:path.flagSet.addFlag('git', g:NERDTreeGitUnchangedIndicator)
     endif
 endfunction
 


### PR DESCRIPTION
Hi everybody !

This PR is pretty self-explanatory, it allows you to display a symbol even if there is no modification on the file.

I'm using this plugin in combination with https://github.com/ryanoasis/vim-devicons, so I felt the need to have a symbol even when there is no change, because without this, the structure becomes quite hard to read. (I can provide a screenshot if it's not clear enough)