### PR TITLE
Fix README.md vimscript code syntax ... but better

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ This issue has been fixed.
 
 Use this variable to change symbols.
 
-	```vimscript
-	let g:NERDTreeIndicatorMapCustom = {
-	    \ "Modified"  : "✹",
-	    \ "Staged"    : "✚",
-	    \ "Untracked" : "✭",
-	    \ "Renamed"   : "➜",
-	    \ "Unmerged"  : "═",
-	    \ "Deleted"   : "✖",
-	    \ "Dirty"     : "✗",
-	    \ "Clean"     : "✔︎",
-        \ 'Ignored'   : '☒',
-	    \ "Unknown"   : "?"
-	    \ }
-	 ```
+```vim
+let g:NERDTreeIndicatorMapCustom = {
+    \ "Modified"  : "✹",
+    \ "Staged"    : "✚",
+    \ "Untracked" : "✭",
+    \ "Renamed"   : "➜",
+    \ "Unmerged"  : "═",
+    \ "Deleted"   : "✖",
+    \ "Dirty"     : "✗",
+    \ "Clean"     : "✔︎",
+    \ 'Ignored'   : '☒',
+    \ "Unknown"   : "?"
+    \ }
+ ```
 
 > How to show `ignored` status?
 


### PR DESCRIPTION
Fix how g:NERDTreeIndicatorMapCustom is displayed from Github:
    Vimscript syntax highlighting now displays properly.
    Backticks and "vimscript" are no longer visible.

On Github:
Tabbing in, and using triple backticks (```) both indicate code blocks.
By doing both simultaneously, the triple backticks become visible
when rendered, which is undesirable.
Using **vim** instead of **vimscript** enables proper vimscript syntax highlighting.