### PR TITLE
Fix color codes leaking out of system() call

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -88,7 +88,7 @@ function! g:NERDTreeGitStatusRefresh()
             let l:gitcmd = l:gitcmd . '=' . g:NERDTreeGitStatusIgnoreSubmodules
         endif
     endif
-    let l:statusesStr = system(l:gitcmd . ' ' . l:root)
+    silent let l:statusesStr = system(l:gitcmd . ' ' . l:root)
     let l:statusesSplit = split(l:statusesStr, '\n')
     if l:statusesSplit != [] && l:statusesSplit[0] =~# 'fatal:.*'
         let l:statusesSplit = []


### PR DESCRIPTION
Under certain situations, what appear to be color codes from the `git status` call show on-screen until a redraw of the affected row occurs.

Example:

![example screenshot](https://i.imgur.com/dlxTRWe.png)

This PR wraps the `git status` call with `:silent` to prevent such output from appearing in the terminal.