### PR TITLE
Don't fail if outside the NERDTree buffer

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -59,14 +59,12 @@ endif
 
 
 function! NERDTreeGitStatusRefreshListener(event)
-    if !g:NERDTree.ExistsForTab() || !g:NERDTree.IsOpen()
+    if !g:NERDTree.ExistsForBuf()
         return
     endif
 
-    let l:NERDTreeBufnr = winbufnr(g:NERDTree.GetWinNum())
-    let l:NOT_A_GIT_REPOSITORY = getbufvar(l:NERDTreeBufnr, 'NOT_A_GIT_REPOSITORY', '')
-    if empty(l:NOT_A_GIT_REPOSITORY)
-        call g:NERDTreeGitStatusRefresh()
+    if !exists('b:NOT_A_GIT_REPOSITORY')
+      call g:NERDTreeGitStatusRefresh()
     endif
     let l:path = a:event.subject
     let l:flag = g:NERDTreeGetGitStatusPrefix(l:path)


### PR DESCRIPTION
This PR fixes two problems (which are essentially the same):

- If the NERDTree root is refreshed while outside the NERDTree buffer, the git plugin will fail because of the listener it attached.
- If the `g:NERDTreeGitStatusRefresh()` function is called outside of a NERDTree buffer it will also fail.

The reason behind the failures is that the `b:NERDTree` variable is not set outside of the NERDTree buffer.
