### PR TITLE
fix syn match pattern for indicator highlight

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -334,7 +334,7 @@ function! s:AddHighlighting()
                 \ }
 
     for l:name in keys(l:synmap)
-        exec 'syn match ' . l:name . ' #' . escape(l:synmap[l:name], '~') . '# containedin=NERDTreeFlags'
+        exec 'syn match ' . l:name . ' #\[\@<=' . escape(l:synmap[l:name], '~') . '\]\@=# containedin=NERDTreeFlags'
     endfor
 
     hi def link NERDTreeGitStatusModified Special


### PR DESCRIPTION
this patch fixes issue #96 

the problem here is that nerdtree display the flag (in this case, the git status indicator) inside a pair of square bracket `[ ]` https://github.com/scrooloose/nerdtree/blob/master/lib/nerdtree/flag_set.vim#L55

my solution is to add a lookbehind & lookahead in the highlight pattern, so that only indicator insidie the square bracket get highlighted.

i'm still using the same custom indicators as in the issue 
```
let g:NERDTreeIndicatorMapCustom = {
    \ "Modified"  : "M",
    \ "Staged"    : "S",
    \ "Untracked" : "+",
    \ "Renamed"   : "R",
    \ "Unmerged"  : "!",
    \ "Deleted"   : "D",
    \ "Dirty"     : "!",
    \ "Clean"     : "C",
    \ 'Ignored'   : '☒',
    \ "Unknown"   : "?"
    \ }
```
as we can see the letter `R` and `M` in `README.md` doesn't get highlighted

![image](https://user-images.githubusercontent.com/10344542/56588297-446b4700-660d-11e9-86e9-573af68422ce.png)
