### PR TITLE
Correct 'git status' syntax with -C option

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -78,7 +78,7 @@ function! g:NERDTreeGitStatusRefresh()
     let b:NOT_A_GIT_REPOSITORY        = 1
 
     let l:root = fnamemodify(b:NERDTree.root.path.str(), ':p:gs?\\?/?:S')
-    let l:gitcmd = 'git -c color.status=false status -s'
+    let l:gitcmd = 'git -c color.status=false -C ' . l:root . ' status -s'
     if g:NERDTreeShowIgnoredStatus
         let l:gitcmd = l:gitcmd . ' --ignored'
     endif
@@ -88,7 +88,7 @@ function! g:NERDTreeGitStatusRefresh()
             let l:gitcmd = l:gitcmd . '=' . g:NERDTreeGitStatusIgnoreSubmodules
         endif
     endif
-    let l:statusesStr = system(l:gitcmd . ' ' . l:root)
+    let l:statusesStr = system(l:gitcmd)
     let l:statusesSplit = split(l:statusesStr, '\n')
     if l:statusesSplit != [] && l:statusesSplit[0] =~# 'fatal:.*'
         let l:statusesSplit = []


### PR DESCRIPTION
Issues like #121 or #104 may be caused by using incorrect `git status <git-dir>` syntax.
Seems it should be `git -C <git-dir> status` as of git version 1.8.5, see [stackoverflow](https://stackoverflow.com/a/35899275)
So it works for me now.