### PR TITLE
Address FileNotFoundError

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -303,17 +303,15 @@ function! s:FileUpdate(fname)
 
     call g:NERDTree.CursorToTreeWin()
     let l:node = b:NERDTree.root.findNode(g:NERDTreePath.New(a:fname))
-    if l:node == {}
-        return
-    endif
-    call l:node.refreshFlags()
-    let l:node = l:node.parent
-    while !empty(l:node)
-        call l:node.refreshDirFlags()
+    if l:node != {}
+        call l:node.refreshFlags()
         let l:node = l:node.parent
-    endwhile
-
-    call NERDTreeRender()
+        while !empty(l:node)
+            call l:node.refreshDirFlags()
+            let l:node = l:node.parent
+        endwhile
+        call NERDTreeRender()
+    endif
 
     exec l:altwinnr . 'wincmd w'
     exec l:winnr . 'wincmd w'


### PR DESCRIPTION
This pull request addresses an issue that may arise when using [nerdtree-git-plugin](https://github.com/Xuyuanp/nerdtree-git-plugin) in conjunction with  [nerdtree](https://github.com/scrooloose/nerdtree), [syntastic](https://github.com/vim-syntastic/syntastic), and [fzf](https://github.com/junegunn/fzf).

```bash
"<redacted>" 247L, 6784C written
syntastic: error: checker output:
Traceback (most recent call last):
  File "/<redacted>/.vim/bundle/syntastic/syntax_checkers/python/compile.py", line 11, in <module>
    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
FileNotFoundError: [Errno 2] No such file or directory: 'NERD_tree_1'
```

**Problem**
![2019-11-21 09 56 04](https://user-images.githubusercontent.com/14130403/69355648-c5dc9380-0c47-11ea-8302-00ca4e71440c.gif)

This only occurs, however, when opening a file with FZF or with `:e`, then opening NERDTree. This is caused by bug in `s:FileUpdate` (also addressed [here]( ).

When a file is opened in this way and the NERDTree is opened, the nodes are not populated and therefore `b:NERDTree.root.findNode` returns `{}`.

This causes execution to return without returning the to the previous window after a call to `g:NERDTree.CursorToTreeWin()`.

This issue then manifests when Syntastic executes. Within the call stack, the filename is derived from the `%` register instead of the buffer number (which is used to determine the filetype and subsequent checkers). Since, `%` has been changed to `NERD_tree_1`, the checker, specifically the Python compiler, fails.

The solution is to refactor the function such that

```vim
exec l:altwinnr . 'wincmd w'
exec l:winnr . 'wincmd w'
```

are always called.

**Solution**
![2019-11-21 10 11 27](https://user-images.githubusercontent.com/14130403/69355701-dc82ea80-0c47-11ea-91fc-f106ac41ab2e.gif)