### PR TITLE
Removed deprecated option 'NERDTreeUpdateOnCursorHold'

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -76,7 +76,6 @@ endfunction
 let s:need_migrate_vals = {
             \ 'g:NERDTreeShowGitStatus':      'g:NERDTreeGitStatusEnable',
             \ 'g:NERDTreeUpdateOnWrite':      'g:NERDTreeGitStatusUpdateOnWrite',
-            \ 'g:NERDTreeUpdateOnCursorHold': 'g:NERDTreeGitStatusUpdateOnCursorHold',
             \ 'g:NERDTreeMapNextHunk':        'g:NERDTreeGitStatusMapNextHunk',
             \ 'g:NERDTreeMapPrevHunk':        'g:NERDTreeGitStatusMapPrevHunk',
             \ 'g:NERDTreeShowIgnoredStatus':  'g:NERDTreeGitStatusShowIgnored',


### PR DESCRIPTION
### Description of Changes

Leave this option used by `vim-devicons` only.

See also https://github.com/ryanoasis/vim-devicons/pull/355