### PR TITLE
Fixed Dirty flag on parent path if it contains Ignored files.

### DIFF
--- a/autoload/gitstatus/util.vim
+++ b/autoload/gitstatus/util.vim
@@ -201,6 +201,9 @@ function! gitstatus#util#ParseGitStatusLine(statusLine, opts) abort
 endfunction
 
 function! gitstatus#util#UpdateParentDirsStatus(cache, root, pathStr, statusKey, opts) abort
+    if a:cache[a:pathStr] ==# 'Ignored'
+        return
+    endif
     let l:dirtyPath = fnamemodify(a:pathStr, ':h')
     let l:dir_dirty_only = get(a:opts, 'NERDTreeGitStatusDirDirtyOnly', 1)
     while l:dirtyPath !=# a:root


### PR DESCRIPTION
If
let g:NERDTreeGitStatusShowIgnored = 1
is enabled then a parent path is shown wrongly as Dirty if
this path is clean but contains Ignored files.

Reproduce:
1. Enable NERDTreeGitStatusShowIgnored
2. Create git repo with a dir "subdir" containing a checked-in file and also add another file in "subdir" which is ignore using .gitignore
3. Start vim and open NERDTree with the git repo as root
4. The "subdir" is marked Dirty (only if NERDTreeGitStatusShowIgnored is enabled)

With this patch the "subdir" is not marked Dirty.