### PR TITLE
Adding "CwdOnly" option to limit the scope of git status

### DIFF
--- a/autoload/gitstatus/util.vim
+++ b/autoload/gitstatus/util.vim
@@ -76,6 +76,10 @@ function! gitstatus#util#BuildGitStatusCommand(root, opts) abort
         let l:cmd += ['--ignore-submodules=' . a:opts['NERDTreeGitStatusIgnoreSubmodules']]
     endif
 
+    if has_key(a:opts, 'NERDTreeGitStatusCwdOnly')
+        let l:cmd += ['.']
+    endif
+
     return l:cmd
 endfunction
 

--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -48,6 +48,7 @@ let s:default_vals = {
             \ 'g:NERDTreeGitStatusShowClean':          0,
             \ 'g:NERDTreeGitStatusLogLevel':           2,
             \ 'g:NERDTreeGitStatusPorcelainVersion':   2,
+            \ 'g:NERDTreeGitStatusCwdOnly':            0,
             \ 'g:NERDTreeGitStatusMapNextHunk':        ']c',
             \ 'g:NERDTreeGitStatusMapPrevHunk':        '[c',
             \ 'g:NERDTreeGitStatusUntrackedFilesMode': 'normal',


### PR DESCRIPTION
### Description of Changes

For repositories with a very large number of files in the working tree (>100k), the `git status` command can take a very long time. A common practice in these sorts of repositories is to not open the editor at the root of the repository, but rather within the particular subcomponent being modified at the time. By adding this scoping option, the performance of NERDTree is vastly improved in these situations.



