### PR TITLE
Prevent 'Undefined variable'

### DIFF
--- a/nerdtree_plugin/git_status.vim
+++ b/nerdtree_plugin/git_status.vim
@@ -325,7 +325,8 @@ function! s:enableLiveUpdate() abort
         " TODO: is it necessary to pass the buffer name?
         autocmd User FugitiveChanged silent! call s:onFileUpdate(expand('%:p'))
 
-        autocmd BufEnter NERD_tree_* call s:onNERDTreeInit(s:path2str(b:NERDTree.root.path))
+        autocmd BufEnter NERD_tree_* if exists('b:NERDTree') |
+                    \ call s:onNERDTreeInit(s:path2str(b:NERDTree.root.path)) | endif
     augroup end
 endfunction
 


### PR DESCRIPTION
### Description of Changes

- checks whether `b:NERDTree` exists before using it

### Motivation

got

```
Error detected while processing BufEnter Autocommands for "NERD_tree_*":
E121: Undefined variable: b:NERDTree
E116: Invalid arguments for function s:path2str(b:NERDTree.root.path))
E116: Invalid arguments for function <SNR>32_onNERDTreeInit
```

when

- try to close one window from outside of the nerdtree and
- got multiple tabs, the closed one is not the last closed tab and
- in a git repo and
- using

```vim
" Close the tab if NERDTree is the only window remaining in it.
autocmd BufEnter * if winnr('$') == 1 && exists('b:NERDTree') && b:NERDTree.isTabTree() | quit | endif
```

from nerdtree's README, they add that a month ago.

Did nerdtree just close itself before autocmd matched `NERD_tree_*` ? I don't really know what's going on, but checking `b:NERDTree`'s existence seems to prevent this error from happening.

Thanks